### PR TITLE
Produce of manifest _directories_

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ fn announce(banner: &str) {
     println!("{}\n{}\n{}", line, banner, line);
 }
 
+/// Get a list of the directories containing each of the packages in the workspace.
 fn find_workspaces() -> Result<Option<Vec<PathBuf>>, Box<Error>> {
     let output = Command::new(CARGO)
         .args(&["metadata", "--no-deps", "-q", "--format-version", "1"])
@@ -39,6 +40,7 @@ fn find_workspaces() -> Result<Option<Vec<PathBuf>>, Box<Error>> {
             .map(|package| {
                 package["manifest_path"]
                     .as_str()
+                    .map(|manifest| manifest.trim_right_matches("Cargo.toml"))
                     .map(PathBuf::from)
                     .ok_or_else(|| "Invalid manifest path".into())
             })


### PR DESCRIPTION
Not the manifest paths themselves...

I think I made a mess of the merge in #4. I've checked that this does in fact now work by installing this locally, and running `cargo multi update` on a large multi-crate workspace - this was successful.